### PR TITLE
feat(show-the-genres): remove track name normalization from popup

### DIFF
--- a/extensions/show-the-genres/popup.tsx
+++ b/extensions/show-the-genres/popup.tsx
@@ -6,7 +6,7 @@ import { lastFmTags, spotifyGenres } from "./app"
 
 export const genrePopup = () => {
     Spicetify.PopupModal.display({
-        title: `Genres of "${normalizeStr(Spicetify.Player.data.track?.metadata?.title!)}"`,
+        title: `Genres of "${Spicetify.Player.data.track?.metadata?.title}"`,
         content: (
             <div className="genres-popup">
                 {spotifyGenres.length === 0 ? <></> : <SpotifyGenresContainer />}


### PR DESCRIPTION
not sure why it was added
why would anyone want a track title to always be in lowercase letters only?