### PR TITLE
feat(extensions): use `Spicetify.Player.data.item`

### DIFF
--- a/extensions/show-the-genres/app.ts
+++ b/extensions/show-the-genres/app.ts
@@ -30,7 +30,7 @@ const updateGenreContainer = async (genres: string[]) => {
 const updateGenresUI = async (genres: string[]) => {
     const trackInfoContainer = await waitForElement("div.main-trackInfo-container")
 
-    const { uri, metadata } = Spicetify.Player.data.track!
+    const { uri, metadata } = Spicetify.Player.data.item!
 
     if (metadata && Spicetify.URI.isTrack(uri) && genres.length) {
         trackInfoContainer?.appendChild(await updateGenreContainer(genres))

--- a/extensions/star-ratings-2/app.ts
+++ b/extensions/star-ratings-2/app.ts
@@ -10,7 +10,7 @@ const { URI } = Spicetify
 loadRatings()
 
 Spicetify.Player.addEventListener("songchange", () => {
-    const npTrack = Spicetify.Player.data.track?.uri!
+    const npTrack = Spicetify.Player.data.item?.uri!
     if (
         Number(CONFIG.skipThreshold) &&
         (tracksRatings[npTrack] || Number.MAX_SAFE_INTEGER) <= Number(CONFIG.skipThreshold)
@@ -19,7 +19,7 @@ Spicetify.Player.addEventListener("songchange", () => {
 
     updateNowPlayingControls(npTrack)
 })
-updateNowPlayingControls(Spicetify.Player.data.track?.uri!)
+updateNowPlayingControls(Spicetify.Player.data.item?.uri!)
 
 let mainElement: HTMLElement
 const mainElementObserver = new MutationObserver(() => updateTrackListControls())

--- a/extensions/star-ratings-2/ratings.ts
+++ b/extensions/star-ratings-2/ratings.ts
@@ -67,7 +67,7 @@ export const toggleRating = async (uri: SpotifyURI, rating: number) => {
         addPlatPlaylistTracks(playlistUri, [uri])
     }
 
-    const npTrack = Spicetify.Player.data.track?.uri
+    const npTrack = Spicetify.Player.data.item?.uri
     if (npTrack === uri) updateNowPlayingControls(npTrack, false)
 
     //TODO: Optimize this, find a way to directly target the pbs for that uri

--- a/extensions/star-ratings/app.ts
+++ b/extensions/star-ratings/app.ts
@@ -193,14 +193,14 @@ const createNowPlayingStars = () => {
 
     addRatingsListenersToStars(
         [nowPlayingStarsContainer, nowPlayingStarConstruct],
-        () => Spicetify.Player.data.track?.uri!,
+        () => Spicetify.Player.data.item?.uri!,
     )
 }
 
 createNowPlayingStars()
 
 export const updateNowPlayingStars = () => {
-    const trackUri = Spicetify.Player.data.track?.uri!
+    const trackUri = Spicetify.Player.data.item?.uri!
     const nowPlayingStarsContainer = getStarsContainer("now-playing")
 
     nowPlayingStarsContainer.style.display = Spicetify.URI.isTrack(trackUri) ? "flex" : "none"


### PR DESCRIPTION
track property is deprecated since Spicetify v2.23.0 https://github.com/spicetify/spicetify-cli/releases/tag/v2.23.0